### PR TITLE
Modified add/delete/update methods to support RabbitMQ queue service.…

### DIFF
--- a/book-service/src/main/java/com/company/bookservice/BookServiceApplication.java
+++ b/book-service/src/main/java/com/company/bookservice/BookServiceApplication.java
@@ -1,5 +1,6 @@
 package com.company.bookservice;
 
+import org.springframework.amqp.rabbit.AsyncRabbitTemplate;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
@@ -21,6 +22,12 @@ public class BookServiceApplication {
 		RabbitTemplate rabbitTemplate = new RabbitTemplate(connectionFactory);
 		rabbitTemplate.setMessageConverter(jackson2JsonMessageConverter());
 		return rabbitTemplate;
+	}
+
+	@Bean
+	public AsyncRabbitTemplate asyncRabbitTemplate(RabbitTemplate rabbitTemplate) {
+		AsyncRabbitTemplate asyncRabbitTemplate = new AsyncRabbitTemplate(rabbitTemplate);
+		return asyncRabbitTemplate;
 	}
 
 	@Bean

--- a/book-service/src/main/java/com/company/bookservice/controller/BookServiceController.java
+++ b/book-service/src/main/java/com/company/bookservice/controller/BookServiceController.java
@@ -1,6 +1,6 @@
 package com.company.bookservice.controller;
 
-import com.company.bookservice.service.ServiceLayer;
+import com.company.bookservice.service.BookServiceLayer;
 import com.company.bookservice.viewmodel.BookViewModel;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.annotation.CacheConfig;
@@ -12,6 +12,8 @@ import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
 
 import static com.insomnyak.util.terminal.AnsiColor.*;
 
@@ -21,12 +23,13 @@ import static com.insomnyak.util.terminal.AnsiColor.*;
 public class BookServiceController {
 
     @Autowired
-    private ServiceLayer sl;
+    BookServiceLayer sl;
 
     @CachePut(key = "#result.getBookId()")
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    public BookViewModel createBook(@RequestBody @Valid BookViewModel bvm) {
+    public BookViewModel createBook(@RequestBody @Valid BookViewModel bvm)
+            throws InterruptedException, ExecutionException, TimeoutException {
         System.out.println(String.format("%sSAVING BOOK AND ADDING TO CACHE%s", BRIGHT_RED, RESET));
         return sl.saveBook(bvm);
     }
@@ -57,6 +60,12 @@ public class BookServiceController {
     @ResponseStatus(HttpStatus.OK)
     public List<BookViewModel> findAllBooks() {
         return sl.findAllBooks();
+    }
+
+    @CacheEvict(allEntries = true)
+    @GetMapping("/clearCache")
+    public String clearCache() {
+        return "Cache Cleared";
     }
 
 }

--- a/book-service/src/main/java/com/company/bookservice/exception/FuturesException.java
+++ b/book-service/src/main/java/com/company/bookservice/exception/FuturesException.java
@@ -1,0 +1,10 @@
+package com.company.bookservice.exception;
+
+public class FuturesException extends RuntimeException {
+    public FuturesException() {
+    }
+
+    public FuturesException(String message) {
+        super(message);
+    }
+}

--- a/book-service/src/main/java/com/company/bookservice/exception/QueueRequestTimeoutException.java
+++ b/book-service/src/main/java/com/company/bookservice/exception/QueueRequestTimeoutException.java
@@ -1,0 +1,10 @@
+package com.company.bookservice.exception;
+
+public class QueueRequestTimeoutException extends RuntimeException {
+    public QueueRequestTimeoutException() {
+    }
+
+    public QueueRequestTimeoutException(String message) {
+        super(message);
+    }
+}

--- a/book-service/src/main/java/com/company/bookservice/service/BookServiceLayer.java
+++ b/book-service/src/main/java/com/company/bookservice/service/BookServiceLayer.java
@@ -1,30 +1,42 @@
 package com.company.bookservice.service;
 
 import com.company.bookservice.dao.BookDao;
+import com.company.bookservice.exception.QueueRequestTimeoutException;
 import com.company.bookservice.model.Book;
 import com.company.bookservice.util.MapClasses;
 import com.company.bookservice.util.feign.NoteServiceClient;
 import com.company.bookservice.viewmodel.BookViewModel;
-import com.company.bookservice.viewmodel.NoteViewModel;
+import com.company.queue.shared.viewmodel.NoteViewModel;
+import org.springframework.amqp.rabbit.AsyncRabbitTemplate;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Primary;
+import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
-@Component
-public class ServiceLayer {
+@Component @Primary
+public class BookServiceLayer {
 
-    BookDao bookDao;
-    NoteServiceClient noteServiceClient;
+    public static final Long TIMEOUT = 1L;
+    public static final TimeUnit TIMEOUT_UNIT = TimeUnit.SECONDS;
+
+    private BookDao bookDao;
+    private NoteServiceLayer nsl;
 
     @Autowired
-    public ServiceLayer(BookDao bookDao, NoteServiceClient noteServiceClient) {
+    public BookServiceLayer(BookDao bookDao, NoteServiceLayer nsl) {
         this.bookDao = bookDao;
-        this.noteServiceClient = noteServiceClient;
+        this.nsl = nsl;
     }
 
     @Transactional
@@ -37,6 +49,7 @@ public class ServiceLayer {
 
         /* if NoteViewModel list is not empty then we call the feign service (NoteServiceClient) to retrieve
          all NoteViewModel to add the notes to the NoteDAO and then setting the ID on the return note*/
+        List<CompletableFuture<NoteViewModel>> listCf = new ArrayList<>();
         if (bookViewModel != null && !bookViewModel.getNotes().isEmpty()) {
             Book finalBook = book;
             bookViewModel.getNotes().stream().forEach(nvm -> {
@@ -44,9 +57,26 @@ public class ServiceLayer {
                     throw new IllegalArgumentException("Please provide content for the note.");
                 }
                 nvm.setBookId(finalBook.getBookId());
-                NoteViewModel nvm2 = saveNote(nvm);
-                nvm.setNoteId(nvm2.getNoteId());
+                CompletableFuture<NoteViewModel> cf = CompletableFuture.supplyAsync(System::nanoTime)
+                        .thenApply(start -> {
+                            NoteViewModel nvm2 = nsl.saveNote(nvm);
+                            return nvm2;
+                        }).thenApply(noteViewModel -> {
+                            nvm.setNoteId(noteViewModel.getNoteId());
+                            return nvm;
+                        });
+                listCf.add(cf);
             });
+            CompletableFuture<Void> allFutures =
+                    CompletableFuture.allOf(listCf.toArray(new CompletableFuture[listCf.size()]));
+            try {
+                allFutures.get(TIMEOUT, TIMEOUT_UNIT);
+            } catch (InterruptedException | ExecutionException e) {
+                throw new RuntimeException(e.getCause() + " | " + e.getMessage());
+            } catch (TimeoutException e) {
+                throw new QueueRequestTimeoutException("The request timed out while waiting for fulfillment. " +
+                        "Your new book has been placed in a queue and will be added shortly.");
+            }
         }
 
 
@@ -60,7 +90,7 @@ public class ServiceLayer {
         BookViewModel bookViewModel = (new MapClasses<>(book, BookViewModel.class))
                 .mapFirstToSecond(false, false);
 
-        List<NoteViewModel> noteViewModelList = findAllNotesByBookId(book.getBookId());
+        List<NoteViewModel> noteViewModelList = nsl.findAllNotesByBookId(book.getBookId());
         bookViewModel.setNotes(noteViewModelList);
 
         return bookViewModel;
@@ -70,7 +100,7 @@ public class ServiceLayer {
         // 1. get all books
         List<Book> bookList = bookDao.getAllBooks();
         // 2. get all notes
-        List<NoteViewModel> noteViewModelList = findAllNotes();
+        List<NoteViewModel> noteViewModelList = nsl.findAllNotes();
         // 3. instantiate bookViewModeList
         List<BookViewModel> bookViewModelList = new ArrayList<>();
 
@@ -100,7 +130,7 @@ public class ServiceLayer {
     }
 
     public void removeBook(Integer bookId) {
-        removeNotesByBookId(bookId);
+        nsl.removeNotesByBookId(bookId);
 
         Book book = bookDao.getBookById(bookId);
 
@@ -131,7 +161,7 @@ public class ServiceLayer {
         }
         List<NoteViewModel> newNotes = bookViewModel.getNotes();
         if (newNotes == null || newNotes.isEmpty()) {
-            removeNotesByBookId(bookId);
+            nsl.removeNotesByBookId(bookId);
         } else {
             // update/delete/add notes
 
@@ -149,7 +179,7 @@ public class ServiceLayer {
              */
 
             // 1. get currentNotes
-            List<NoteViewModel> currentNotes = findAllNotesByBookId(bookId);
+            List<NoteViewModel> currentNotes = nsl.findAllNotesByBookId(bookId);
 
             // 2. filter currentNotes for ones not present in newNotes >> notesToDelete
             List<NoteViewModel> notesToDelete = currentNotes.stream().filter(nvm -> {
@@ -160,7 +190,7 @@ public class ServiceLayer {
             }).collect(Collectors.toList());
 
             // 3. delete notesToDelete
-            notesToDelete.forEach(nvm -> removeNote(nvm.getNoteId()));
+            notesToDelete.forEach(nvm -> nsl.removeNote(nvm.getNoteId()));
 
             // 4. for newNotes
             for (NoteViewModel newNote : newNotes) {
@@ -172,49 +202,24 @@ public class ServiceLayer {
                             .anyMatch(nvm -> nvm.getNoteId().equals(newNote.getNoteId()));
                     // ii. if id is found >> update
                     if (inCurrentNotes) {
-                        updateNote(newNote);
+                        nsl.updateNote(newNote);
                     } else {
                         // iii. if id is not found >> create new note and update id
                         if (newNote.getNote() == null || newNote.getNote().trim().length() == 0) {
                             throw new IllegalArgumentException("Please provide content for the note.");
                         }
                         newNote.setBookId(bookId);
-                        NoteViewModel createdNote = saveNote(newNote);
+                        NoteViewModel createdNote = nsl.saveNote(newNote);
                         newNote.setNoteId(createdNote.getNoteId());
                     }
                 } else {
                     // - if id is not present:
                     // i. create new note and update id
                     newNote.setBookId(bookId);
-                    NoteViewModel createdNote = saveNote(newNote);
+                    NoteViewModel createdNote = nsl.saveNote(newNote);
                     newNote.setNoteId(createdNote.getNoteId());
                 }
             }
         }
-    }
-
-    @Transactional
-    private NoteViewModel saveNote(NoteViewModel nvm) {
-        return noteServiceClient.createNote(nvm);
-    }
-
-    private List<NoteViewModel> findAllNotes() {
-        return noteServiceClient.getAllNotes();
-    }
-
-    private void updateNote(NoteViewModel nvm) {
-        noteServiceClient.updateNote(nvm.getNoteId(), nvm);
-    }
-
-    private void removeNote(Integer noteId) {
-        noteServiceClient.deleteNote(noteId);
-    }
-
-    private void removeNotesByBookId(Integer bookId) {
-        noteServiceClient.deleteNotesByBookId(bookId);
-    }
-
-    private List<NoteViewModel> findAllNotesByBookId(Integer bookId) {
-        return noteServiceClient.getNotesByBookId(bookId);
     }
 }

--- a/book-service/src/main/java/com/company/bookservice/service/NoteServiceLayer.java
+++ b/book-service/src/main/java/com/company/bookservice/service/NoteServiceLayer.java
@@ -1,0 +1,70 @@
+package com.company.bookservice.service;
+
+import com.company.bookservice.util.feign.NoteServiceClient;
+import com.company.queue.shared.viewmodel.NoteViewModel;
+import org.springframework.amqp.rabbit.AsyncRabbitTemplate;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+@Component
+public class NoteServiceLayer {
+
+    public static final String EXCHANGE = "note-exchange";
+    public static final String ROUTING_KEY_ADD = "note.add.book.service";
+    public static final String ROUTING_KEY_UPDATE = "note.update.book.service";
+    public static final String ROUTING_KEY_DELETE = "note.delete.book.service";
+    public static final String ROUTING_KEY_DELETE_BY_BOOK_ID = "note.deleteByBookId.book.service";
+    public static final Long TIMEOUT = 8L;
+    public static final TimeUnit TIMEOUT_UNIT = TimeUnit.SECONDS;
+
+    private AsyncRabbitTemplate rabbitTemplate;
+    private NoteServiceClient noteServiceClient;
+
+    @Autowired
+    public NoteServiceLayer(AsyncRabbitTemplate rabbitTemplate,
+                            NoteServiceClient noteServiceClient) {
+        this.rabbitTemplate = rabbitTemplate;
+        this.noteServiceClient = noteServiceClient;
+    }
+
+    @Transactional
+    NoteViewModel saveNote(NoteViewModel nvm) {
+        try {
+            return (NoteViewModel) rabbitTemplate.convertSendAndReceiveAsType(EXCHANGE, ROUTING_KEY_ADD, nvm,
+                    ParameterizedTypeReference.forType(NoteViewModel.class)).get(TIMEOUT, TIMEOUT_UNIT);
+        } catch (InterruptedException | TimeoutException | ExecutionException e) {
+            throw new RuntimeException(e.getCause() + " \n " + e.getMessage());
+        }
+        //return noteServiceClient.createNote(nvm);
+    }
+
+    List<NoteViewModel> findAllNotes() {
+        return noteServiceClient.getAllNotes();
+    }
+
+    void updateNote(NoteViewModel nvm) {
+        rabbitTemplate.convertSendAndReceive(EXCHANGE, ROUTING_KEY_UPDATE, nvm);
+        //noteServiceClient.updateNote(nvm.getNoteId(), nvm);
+    }
+
+    void removeNote(Integer noteId) {
+        rabbitTemplate.convertSendAndReceive(EXCHANGE, ROUTING_KEY_DELETE, noteId);
+        //noteServiceClient.deleteNote(noteId);
+    }
+
+    void removeNotesByBookId(Integer bookId) {
+        rabbitTemplate.convertSendAndReceive(EXCHANGE, ROUTING_KEY_DELETE_BY_BOOK_ID, bookId);
+        //noteServiceClient.deleteNotesByBookId(bookId);
+    }
+
+    List<NoteViewModel> findAllNotesByBookId(Integer bookId) {
+        return noteServiceClient.getNotesByBookId(bookId);
+    }
+}

--- a/book-service/src/main/java/com/company/bookservice/util/feign/NoteServiceClient.java
+++ b/book-service/src/main/java/com/company/bookservice/util/feign/NoteServiceClient.java
@@ -1,6 +1,6 @@
 package com.company.bookservice.util.feign;
 
-import com.company.bookservice.viewmodel.NoteViewModel;
+import com.company.queue.shared.viewmodel.NoteViewModel;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;

--- a/book-service/src/main/java/com/company/bookservice/viewmodel/BookViewModel.java
+++ b/book-service/src/main/java/com/company/bookservice/viewmodel/BookViewModel.java
@@ -1,5 +1,7 @@
 package com.company.bookservice.viewmodel;
 
+import com.company.queue.shared.viewmodel.NoteViewModel;
+
 import javax.validation.Valid;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.Size;

--- a/book-service/src/main/java/com/company/queue/shared/viewmodel/NoteViewModel.java
+++ b/book-service/src/main/java/com/company/queue/shared/viewmodel/NoteViewModel.java
@@ -1,4 +1,4 @@
-package com.company.bookservice.viewmodel;
+package com.company.queue.shared.viewmodel;
 
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.Size;
@@ -51,5 +51,14 @@ public class NoteViewModel {
     @Override
     public int hashCode() {
         return Objects.hash(getNoteId(), getBookId(), getNote());
+    }
+
+    @Override
+    public String toString() {
+        return "NoteViewModel{" +
+                "noteId=" + noteId +
+                ", bookId=" + bookId +
+                ", note='" + note + '\'' +
+                '}';
     }
 }

--- a/book-service/src/main/resources/application.properties
+++ b/book-service/src/main/resources/application.properties
@@ -1,1 +1,3 @@
 
+spring.mvc.throw-exception-if-no-handler-found=true
+spring.resources.add-mappings=false

--- a/note-service/src/main/java/com/company/noteservice/NoteServiceApplication.java
+++ b/note-service/src/main/java/com/company/noteservice/NoteServiceApplication.java
@@ -1,14 +1,17 @@
 package com.company.noteservice;
 
-import org.springframework.amqp.core.Binding;
-import org.springframework.amqp.core.BindingBuilder;
-import org.springframework.amqp.core.Queue;
-import org.springframework.amqp.core.TopicExchange;
+import org.springframework.amqp.core.*;
 import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @SpringBootApplication
 @EnableDiscoveryClient
@@ -29,7 +32,7 @@ public class NoteServiceApplication {
 	}
 
 	@Bean
-	Binding binding(Queue queue, TopicExchange exchange) {
+	Binding bindingAdd(Queue queue, TopicExchange exchange) {
 		return BindingBuilder.bind(queue).to(exchange).with(ROUTING_KEY);
 	}
 

--- a/note-service/src/main/java/com/company/noteservice/controller/NoteServiceController.java
+++ b/note-service/src/main/java/com/company/noteservice/controller/NoteServiceController.java
@@ -2,6 +2,8 @@ package com.company.noteservice.controller;
 
 import com.company.noteservice.dao.NoteDao;
 import com.company.noteservice.model.Note;
+import com.company.noteservice.service.ServiceLayer;
+import com.company.queue.shared.viewmodel.NoteViewModel;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.context.config.annotation.RefreshScope;
 import org.springframework.http.HttpStatus;
@@ -16,40 +18,43 @@ public class NoteServiceController {
     @Autowired
     NoteDao noteDao;
 
+    @Autowired
+    ServiceLayer sl;
+
     @RequestMapping(value = "/notes", method = RequestMethod.POST)
-    Note createNote(@RequestBody Note note) {
-        return noteDao.add(note);
+    NoteViewModel createNote(@RequestBody NoteViewModel nvm) {
+        return sl.save(nvm);
     }
 
     @RequestMapping(value = "/notes/{id}", method = RequestMethod.GET)
-    Note getNote(@PathVariable(name = "id") Integer noteId) {
-        return noteDao.find(noteId);
+    NoteViewModel getNote(@PathVariable(name = "id") Integer noteId) {
+        return sl.find(noteId);
     }
 
     @RequestMapping(value = "/notes/book/{book_id}", method = RequestMethod.GET)
-    List<Note> getNotesByBookId(@PathVariable(name = "book_id") Integer bookId) {
-        return noteDao.findByBookId(bookId);
+    List<NoteViewModel> getNotesByBookId(@PathVariable(name = "book_id") Integer bookId) {
+        return sl.findByBookId(bookId);
     }
 
     @RequestMapping(value = "/notes", method = RequestMethod.GET)
-    List<Note> getAllNotes() {
-        return noteDao.findAll();
+    List<NoteViewModel> getAllNotes() {
+        return sl.findAll();
     }
 
     @RequestMapping(value = "/notes/{id}", method = RequestMethod.PUT)
-    void updateNote(@PathVariable Integer id, @RequestBody Note note) {
-        noteDao.update(id, note);
+    void updateNote(@PathVariable Integer id, @RequestBody NoteViewModel nvm) {
+        sl.update(nvm);
     }
 
     @RequestMapping(value = "/notes/{id}", method = RequestMethod.DELETE)
     void deleteNote(@PathVariable(name = "id") Integer noteId) {
-        noteDao.delete(noteId);
+        sl.remove(noteId);
     }
 
     @RequestMapping(value = "/notes/book/{id}", method = RequestMethod.DELETE)
     @ResponseStatus(HttpStatus.NO_CONTENT)
     void deleteNoteByBookId(@PathVariable(name = "id") Integer id){
-        noteDao.deleteByBookId(id);
+        sl.removeByBookId(id);
     }
 
 }

--- a/note-service/src/main/java/com/company/noteservice/model/Note.java
+++ b/note-service/src/main/java/com/company/noteservice/model/Note.java
@@ -55,4 +55,13 @@ public class Note {
     public int hashCode() {
         return Objects.hash(getNoteId(), getBookId(), getNote());
     }
+
+    @Override
+    public String toString() {
+        return "Note{" +
+                "noteId=" + noteId +
+                ", bookId=" + bookId +
+                ", note='" + note + '\'' +
+                '}';
+    }
 }

--- a/note-service/src/main/java/com/company/noteservice/queue/MessageListener.java
+++ b/note-service/src/main/java/com/company/noteservice/queue/MessageListener.java
@@ -1,15 +1,50 @@
 package com.company.noteservice.queue;
 
 import com.company.noteservice.NoteServiceApplication;
-import com.company.noteservice.model.Note;
+import com.company.noteservice.service.ServiceLayer;
+import com.company.queue.shared.viewmodel.NoteViewModel;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.amqp.support.AmqpHeaders;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.stereotype.Service;
+import org.springframework.amqp.core.Message;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
 
 @Service
 public class MessageListener {
 
+    @Autowired
+    ServiceLayer sl;
+
+    @Autowired
+    ObjectMapper mapper;
+
     @RabbitListener(queues = NoteServiceApplication.QUEUE_NAME)
-    public void receiveMessage(Note note) {
-        System.out.println("RECEIVED NOTE: " + note.getNoteId());
+    public NoteViewModel receiveMessageToAddUpdateNote(Message message,
+                                                       @Header(AmqpHeaders.RECEIVED_ROUTING_KEY) String key)
+            throws IOException {
+
+        String body = new String(message.getBody(), Charset.defaultCharset().name());
+        System.out.println("RECEIVED || key: " + key + " | body: " + body);
+        if (key.matches("^note[.]add[.].*$")) {
+            NoteViewModel nvm = mapper.readValue(body, NoteViewModel.class);
+            return sl.save(nvm);
+        } else if (key.matches("^note[.]update[.].*$")) {
+            NoteViewModel nvm = mapper.readValue(body, NoteViewModel.class);
+            sl.update(nvm);
+            return null;
+        } else if (key.matches("^note[.]delete[.].*$")) {
+            sl.remove(Integer.parseInt(body));
+            return null;
+        } else if (key.matches("^note[.]deleteByBookId[.].*$")) {
+            sl.removeByBookId(Integer.parseInt(body));
+            return null;
+        } else {
+            return null;
+        }
     }
 }

--- a/note-service/src/main/java/com/company/noteservice/service/ServiceLayer.java
+++ b/note-service/src/main/java/com/company/noteservice/service/ServiceLayer.java
@@ -1,0 +1,63 @@
+package com.company.noteservice.service;
+
+import com.company.noteservice.dao.NoteDao;
+import com.company.noteservice.model.Note;
+import com.company.noteservice.util.MapClasses;
+import com.company.queue.shared.viewmodel.NoteViewModel;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+public class ServiceLayer {
+
+    NoteDao noteDao;
+
+    @Autowired
+    public ServiceLayer(NoteDao noteDao) {
+        this.noteDao = noteDao;
+    }
+
+    public NoteViewModel save(NoteViewModel nvm) {
+        Note note = (new MapClasses<>(nvm, Note.class)).mapFirstToSecond(false);
+        noteDao.add(note);
+        nvm.setNoteId(note.getNoteId());
+        return nvm;
+    }
+
+    public void update(NoteViewModel nvm) {
+        Note note = (new MapClasses<>(nvm, Note.class)).mapFirstToSecond(false);
+        noteDao.update(nvm.getNoteId(), nvm);
+    }
+
+    public void remove(Integer noteId) {
+        noteDao.delete(noteId);
+    }
+
+    public void removeByBookId(Integer bookId) {
+        noteDao.deleteByBookId(bookId);
+    }
+
+    public NoteViewModel find(Integer noteId) {
+        Note note = noteDao.find(noteId);
+        return (new MapClasses<>(note, NoteViewModel.class)).mapFirstToSecond(false);
+    }
+
+    public List<NoteViewModel> findByBookId(Integer bookId) {
+        List<Note> notes = noteDao.findByBookId(bookId);
+        List<NoteViewModel> noteViewModels = new ArrayList<>();
+        notes.forEach(note -> noteViewModels
+                .add((new MapClasses<>(note, NoteViewModel.class)).mapFirstToSecond(false)));
+        return noteViewModels;
+    }
+
+    public List<NoteViewModel> findAll() {
+        List<Note> notes = noteDao.findAll();
+        List<NoteViewModel> noteViewModels = new ArrayList<>();
+        notes.forEach(note -> noteViewModels
+                .add((new MapClasses<>(note, NoteViewModel.class)).mapFirstToSecond(false)));
+        return noteViewModels;
+    }
+}

--- a/note-service/src/main/java/com/company/queue/shared/viewmodel/NoteViewModel.java
+++ b/note-service/src/main/java/com/company/queue/shared/viewmodel/NoteViewModel.java
@@ -1,0 +1,6 @@
+package com.company.queue.shared.viewmodel;
+
+import com.company.noteservice.model.Note;
+
+public class NoteViewModel extends Note {
+}


### PR DESCRIPTION
… In BookService, moved Note methods to its own SL in order to mock tests accordingly, since parts of the AsyncRabbitTemplate could not be mocked correclty. Moved NoteViewModel to the package com.company.queue.shared.viewmodel; seems both services need to the model been sent/received to be of the same Type/package. Modified mock tests. On the consumer end, modified Note service to receive any message to the queue, and then call the appropriate add/update/delete methods according to the binding keys. Added a SL to separate the small amount of logic from the other layers.